### PR TITLE
feat: Add tasks preview card to party hub for organizers and admins

### DIFF
--- a/finalsend/Features/PartyDetail/Views/PartyHubView.swift
+++ b/finalsend/Features/PartyDetail/Views/PartyHubView.swift
@@ -490,6 +490,17 @@ struct PartyHubView: View {
                     action: { showEditPartyTypeModal = true }
                 )
                 
+                // Tasks (summary row) - only visible for organizers and admins
+                if partyManager.isOrganizerOrAdmin {
+                    FeaturePreviewCard(
+                        title: "Tasks",
+                        subtitle: "Manage party tasks & to-dos",
+                        icon: "checklist",
+                        color: Color.brandBlue,
+                        action: { showTasksModal = true }
+                    )
+                }
+                
                 // Dates (summary row)
                 FeaturePreviewCard(
                     title: "Dates",
@@ -674,7 +685,8 @@ struct PartyHubView: View {
                 currentUserRole: dataManager.attendees.first(where: { $0.isCurrentUser })?.role ?? .attendee,
                 destinationCity: dataManager.currentCity?.city,
                 partyStartDate: partyManager.startDate,
-                partyEndDate: partyManager.endDate
+                partyEndDate: partyManager.endDate,
+                onDismiss: { showTransportModal = false }
             )
         }
         .fullScreenCover(isPresented: $showLodgingModal) {


### PR DESCRIPTION
- Add tasks preview card between party type and dates
- Only visible for users with organizer or admin role
- Uses existing showTasksModal state and action
- Maintains consistent UI design with other feature cards