### PR TITLE
feat: Integrate custom merch shop with 6 hardcoded products

### DIFF
--- a/finalsend/Features/PartyDetail/Tabs/Shop/Models/Product.swift
+++ b/finalsend/Features/PartyDetail/Tabs/Shop/Models/Product.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+struct Product: Identifiable, Codable {
+    let id: String
+    let name: String
+    let price: Double
+    let imageName: String
+    let description: String
+    
+    var displayPrice: String {
+        return String(format: "$%.2f", price)
+    }
+    
+    static let sampleProducts: [Product] = [
+        Product(
+            id: "tshirt",
+            name: "Custom T-Shirt",
+            price: 29.99,
+            imageName: "tshirt-white",
+            description: "Custom party t-shirt with your crew's design"
+        ),
+        Product(
+            id: "longsleeve",
+            name: "Custom Long Sleeve",
+            price: 34.99,
+            imageName: "longsleeve-white",
+            description: "Custom long sleeve shirt for cooler weather"
+        ),
+        Product(
+            id: "hoodie",
+            name: "Custom Hoodies",
+            price: 49.99,
+            imageName: "hoodie-white",
+            description: "Comfortable custom hoodies for the whole crew"
+        ),
+        Product(
+            id: "hat",
+            name: "Custom Hats",
+            price: 29.99,
+            imageName: "hat-white",
+            description: "Custom baseball caps with your party theme"
+        ),
+        Product(
+            id: "crewneck",
+            name: "Custom Crewnecks",
+            price: 49.99,
+            imageName: "crewneck-white",
+            description: "Classic crewneck sweatshirts with custom design"
+        ),
+        Product(
+            id: "bag",
+            name: "Custom Bags",
+            price: 19.99,
+            imageName: "bag-white",
+            description: "Custom tote bags for carrying party essentials"
+        )
+    ]
+}

--- a/finalsend/Features/PartyDetail/Tabs/Shop/Views/ProductCard.swift
+++ b/finalsend/Features/PartyDetail/Tabs/Shop/Views/ProductCard.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct ProductCard: View {
+    let product: Product
+    let onTap: () -> Void
+    
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 0) {
+                // Product Image
+                ZStack {
+                    Rectangle()
+                        .fill(Color.white)
+                        .aspectRatio(1, contentMode: .fit)
+                    
+                    Image(product.imageName)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .padding(20)
+                        .onAppear {
+                            print("Loading image: \(product.imageName)")
+                        }
+                }
+                
+                // Product Info Section (White Background)
+                VStack(spacing: 8) {
+                    Text(product.name)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity)
+                    
+                    // Pricing
+                    Text(product.displayPrice)
+                        .font(.caption)
+                        .fontWeight(.bold)
+                        .foregroundColor(Color(hex: "#401B17"))
+                        .frame(maxWidth: .infinity)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.white) // Clean white background
+                .overlay(
+                    Rectangle()
+                        .frame(height: 1)
+                        .foregroundColor(Color.gray.opacity(0.3))
+                        .offset(y: -0.5),
+                    alignment: .top
+                )
+            }
+            .background(Color.white)
+            .cornerRadius(12)
+            .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    ProductCard(
+        product: Product.sampleProducts[0],
+        onTap: {}
+    )
+    .padding()
+}

--- a/finalsend/Features/PartyDetail/Tabs/Shop/Views/ShopProductsView.swift
+++ b/finalsend/Features/PartyDetail/Tabs/Shop/Views/ShopProductsView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct ShopProductsView: View {
+    let userRole: String
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 20) {
+                    
+                    
+                    // Products Grid
+                    LazyVGrid(columns: [
+                        GridItem(.flexible(), spacing: 16),
+                        GridItem(.flexible(), spacing: 16)
+                    ], spacing: 16) {
+                        ForEach(Product.sampleProducts) { product in
+                            ProductCard(product: product) {
+                                // Handle product selection
+                                print("Selected product: \(product.name)")
+                            }
+                        }
+                    }
+                    .padding(.horizontal)
+                    
+                    // Contact Info
+                    VStack(spacing: 8) {
+                        Text("💬 Contact Us!")
+                            .font(.headline)
+                            .foregroundColor(.secondary)
+                        
+                        Text("Custom design uploads coming soon! For now, contact us on Instagram for high-quality custom merch at great prices.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal)
+                    }
+                    .padding(.vertical)
+                    .background(Color.gray.opacity(0.05))
+                    .cornerRadius(12)
+                    .padding(.horizontal)
+                    
+                    Spacer(minLength: 20)
+                }
+            }
+            .navigationTitle("Custom Merch")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarBackButtonHidden(true)
+            .navigationBarItems(
+                leading: Button("Back") {
+                    dismiss()
+                }
+            )
+        }
+    }
+}
+
+#Preview {
+    NavigationView {
+        ShopProductsView(userRole: "attendee")
+    }
+}

--- a/finalsend/Features/PartyDetail/Tabs/Shop/Views/ShopTabView.swift
+++ b/finalsend/Features/PartyDetail/Tabs/Shop/Views/ShopTabView.swift
@@ -4,41 +4,7 @@ struct ShopTabView: View {
     let userRole: String
     
     var body: some View {
-        NavigationView {
-            VStack {
-                Spacer()
-                
-                VStack(spacing: 16) {
-                    Image(systemName: "tshirt")
-                        .font(.system(size: 64))
-                        .foregroundColor(.mint)
-                    
-                    Text("Shop")
-                        .font(.title)
-                        .fontWeight(.bold)
-                    
-                    Text("Party merch")
-                        .font(.body)
-                        .foregroundColor(.secondary)
-                        .multilineTextAlignment(.center)
-                    
-                    Text("Coming soon...")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                .padding()
-                
-                Spacer()
-            }
-            .navigationTitle("Shop")
-            .navigationBarTitleDisplayMode(.inline)
-            .navigationBarBackButtonHidden(true)
-            .navigationBarItems(
-                leading: Button("Back") {
-                    // This will be handled by the fullScreenCover dismissal
-                }
-            )
-        }
+        ShopProductsView(userRole: userRole)
     }
 }
 

--- a/finalsend/Features/PartyDetail/Views/PartyHubView.swift
+++ b/finalsend/Features/PartyDetail/Views/PartyHubView.swift
@@ -622,8 +622,8 @@ struct PartyHubView: View {
                     action: { showPackingModal = true }
                 )
                 FeaturePreviewCard(
-                    title: "Shop",
-                    subtitle: "Merch & supplies",
+                    title: "Merch",
+                    subtitle: "Custom apparel & accessories",
                     icon: "tshirt",
                     color: Color.brandBlue,
                     action: { showShopModal = true }


### PR DESCRIPTION
- Add Product model with 6 custom apparel items (tshirts, hoodies, hats, etc.)
- Create ProductCard component with white backgrounds and subtle separators
- Implement ShopProductsView with grid layout and clean navigation
- Update ShopTabView to use new shop implementation
- Change shop card in PartyHub to 'Merch' with 'Custom apparel & accessories' subtitle
- Remove redundant titles and update messaging to be more positive
- Add back button and proper navigation controls